### PR TITLE
Add license tag

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,7 @@ setuptools.setup(
     author="mampfes",
     author_email="mampfes@users.noreply.github.com",
     description="Python 3 package to interface devices from STALL WIFFI.",
+    license="MIT",
     long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/mampfes/python-wiffi",


### PR DESCRIPTION
Allow third-party tools (e.g., PyPI) to get the license in an easy way. 